### PR TITLE
Use history API instead of window.location.hash

### DIFF
--- a/src/hooks/useSetMarsQueryParams.ts
+++ b/src/hooks/useSetMarsQueryParams.ts
@@ -25,7 +25,7 @@ export default function useSetMarsQueryParams(sceneView: any) {
 
 function setMarsQueryParams(sceneView: any) {
   const marsUrlParams = getMarsQueryParams(sceneView);
-  window.location.hash = queryString.stringify(marsUrlParams);
+  window.history.replaceState(marsUrlParams, document.title, queryString.stringify(marsUrlParams));
 }
 
 function getMarsQueryParams(sceneView: any) {

--- a/src/hooks/useSetMarsQueryParams.ts
+++ b/src/hooks/useSetMarsQueryParams.ts
@@ -25,7 +25,7 @@ export default function useSetMarsQueryParams(sceneView: any) {
 
 function setMarsQueryParams(sceneView: any) {
   const marsUrlParams = getMarsQueryParams(sceneView);
-  window.history.replaceState(marsUrlParams, document.title, queryString.stringify(marsUrlParams));
+  window.history.replaceState(marsUrlParams, document.title, '#' + queryString.stringify(marsUrlParams));
 }
 
 function getMarsQueryParams(sceneView: any) {


### PR DESCRIPTION
Fixes #1

There's nothing wrong with changing the URL every time the map is panned around, but the way you were previously doing it was wrong and is why the history was filling up.

This is an (untested) PR to do it properly, using the history API.